### PR TITLE
mDNS の txt レコードサポート

### DIFF
--- a/libraries/ESPmDNS/src/ESPmDNS.cpp
+++ b/libraries/ESPmDNS/src/ESPmDNS.cpp
@@ -200,7 +200,7 @@ int MDNSResponder::numTxt(int idx) {
         token = strtok(i == 0 ? (char*)result->txt : NULL, "&");
         i++;
     }while(token != NULL);
-    return i;
+    return i - 1;
 }
 
 bool MDNSResponder::hasTxt(int idx, const char * key) {
@@ -236,7 +236,7 @@ String MDNSResponder::txt(int idx, const char * key) {
         i++;
     }while(token != NULL);
 
-    return result->txt != NULL ? result->txt : "";
+    return "";
 }
 
 String MDNSResponder::txt(int idx, int txtIdx) {

--- a/libraries/ESPmDNS/src/ESPmDNS.cpp
+++ b/libraries/ESPmDNS/src/ESPmDNS.cpp
@@ -184,4 +184,83 @@ uint16_t MDNSResponder::port(int idx) {
     return result->port;
 }
 
+int MDNSResponder::numTxt(int idx) {
+    const mdns_result_t * result = mdns_result_get(mdns, idx);
+    if(!result){
+        log_e("Result %d not found", idx);
+        return 0;
+    }
+    if (result->txt == NULL || strcmp(result->txt, "") == 0) {
+        log_e("Result %d has no txt", idx);
+        return 0;
+    }
+    int i = 0;
+    char* token = NULL;
+    do {
+        token = strtok(i == 0 ? (char*)result->txt : NULL, "&");
+        i++;
+    }while(token != NULL);
+    return i;
+}
+
+bool MDNSResponder::hasTxt(int idx, const char * key) {
+    const mdns_result_t * result = mdns_result_get(mdns, idx);
+    if(!result){
+        log_e("Result %d not found", idx);
+        return false;
+    }
+    return result->txt != NULL && strcmp(result->txt, "") != 0;
+}
+
+String MDNSResponder::txt(int idx, const char * key) {
+    const mdns_result_t * result = mdns_result_get(mdns, idx);
+    if(!result){
+        log_e("Result %d not found", idx);
+        return "";
+    }
+    if (result->txt == NULL || strcmp(result->txt, "") == 0) {
+        log_e("Result %d has no txt", idx);
+        return "";
+    }
+    int i = 0;
+    char* token = NULL;
+    do {
+        token = strtok(i == 0 ? (char*)result->txt : NULL, "&");
+        int j = 0;
+        while (token[j] == key[j]) {
+            j++;
+        }
+        if (token[j] == '=' && key[j] == '\0') {
+            return token+j+1;
+        }
+        i++;
+    }while(token != NULL);
+
+    return result->txt != NULL ? result->txt : "";
+}
+
+String MDNSResponder::txt(int idx, int txtIdx) {
+    const mdns_result_t * result = mdns_result_get(mdns, idx);
+    if(!result){
+        log_e("Result %d not found", idx);
+        return "";
+    }
+    if (result->txt == NULL || strcmp(result->txt, "") == 0) {
+        log_e("Result %d has no txt", idx);
+        return "";
+    }
+    int i = 0;
+    char* token = NULL;
+    do {
+        token = strtok(i == 0 ? (char*)result->txt : NULL, "&");
+        if (i == idx) {
+            char* key = strtok(token, "=");
+            char* value = strtok(NULL, "=");
+            return value;
+        }
+        i++;
+    }while(token != NULL);
+    return "";
+}
+
 MDNSResponder MDNS;

--- a/libraries/ESPmDNS/src/ESPmDNS.h
+++ b/libraries/ESPmDNS/src/ESPmDNS.h
@@ -105,7 +105,12 @@ public:
   String hostname(int idx);
   IPAddress IP(int idx);
   uint16_t port(int idx);
-  
+
+  int numTxt(int idx);
+  bool hasTxt(int idx, const char * key);
+  String txt(int idx, const char * key);
+  String txt(int idx, int txtIdx);
+
 private:
   mdns_server_t * mdns;
   tcpip_adapter_if_t _if;


### PR DESCRIPTION
mDNS レスポンスからの txt レコード取得を、[arduino-esp32 の最新の I/F](https://github.com/espressif/arduino-esp32/blob/master/libraries/ESPmDNS/src/ESPmDNS.cpp#L288) に合わせて実装しました。

\# ほぼ [esp8266-google-home-notifier の issue](https://github.com/horihiro/esp8266-google-home-notifier/issues/1)のためだけですが。